### PR TITLE
Added get row method to action, to allow getting row data in presenter

### DIFF
--- a/src/Components/Action.php
+++ b/src/Components/Action.php
@@ -252,6 +252,16 @@ class Action extends MockArray implements ActionContract
     }
 
     /**
+     * Returns the current row set on the action
+     *
+     * @return mixed
+     */
+    public function getRow()
+    {
+        return $this->row;
+    }
+
+    /**
      * Set the presenter callback for the action.
      *
      * @param  Closure $callback

--- a/src/Contracts/Action.php
+++ b/src/Contracts/Action.php
@@ -62,6 +62,13 @@ interface Action
     public function row($row = false);
 
     /**
+     * Returns the current row set on the action
+     *
+     * @return mixed
+     */
+    public function getRow();
+
+    /**
      * Add a callback to be run to validate that this action is to be used
      * for the current row.
      *


### PR DESCRIPTION
I've added a getRow method to the Action class so I can change the action label based on row values
(e.g. if a row is marked as "pinned", I can use the row data to change an icon on the action to show this as pinned to the user)